### PR TITLE
Catch write errors

### DIFF
--- a/src/endian.jl
+++ b/src/endian.jl
@@ -6,9 +6,9 @@ const BIG_ENDFLAG = UInt8(255)
 
 function write_endian(io::IOStream)
     if Base.ENDIAN_BOM == LIT_ENDIAN
-        write(io, LIT_ENDFLAG)
+        write_or_err(io, LIT_ENDFLAG)
     elseif Base.ENDIAN_BOM == BIG_ENDIAN
-        write(io, BIG_ENDFLAG)
+        write_or_err(io, BIG_ENDFLAG)
     else
         error("ENDIAN_BOM of ", Base.ENDIAN_BOM, " not recognized")
     end


### PR DESCRIPTION
This is a workaround for JuliaLang/julia#44535, catching write errors that are missed by `Base.write` instead of producing corrupt `abf` files.
Specifically, this catches trying to write to a full file system (but maybe also some other cases?).